### PR TITLE
Adding support for Ed25519 signature algorithm and tests

### DIFF
--- a/tests/test_webauthn.py
+++ b/tests/test_webauthn.py
@@ -9,6 +9,7 @@ from webauthn import const
 HERE = os.path.abspath(os.path.dirname(__file__))
 TRUST_ANCHOR_DIR = "{}/../webauthn/trusted_attestation_roots".format(HERE)
 
+
 class WebAuthnES256Test(unittest.TestCase):
     REGISTRATION_RESPONSE_TMPL = {
         'clientData': b'eyJ0eXBlIjogIndlYmF1dGhuLmNyZWF0ZSIsICJjbGllbnRFeHRlbnNpb25zIjoge30sICJjaGFsbGVuZ2UiOiAiYlB6cFgzaEhRdHNwOWV2eUtZa2FadFZjOVVOMDdQVWRKMjJ2WlVkRHA5NCIsICJvcmlnaW4iOiAiaHR0cHM6Ly93ZWJhdXRobi5pbyJ9',  # noqa

--- a/tests/test_webauthn.py
+++ b/tests/test_webauthn.py
@@ -9,7 +9,6 @@ from webauthn import const
 HERE = os.path.abspath(os.path.dirname(__file__))
 TRUST_ANCHOR_DIR = "{}/../webauthn/trusted_attestation_roots".format(HERE)
 
-
 class WebAuthnES256Test(unittest.TestCase):
     REGISTRATION_RESPONSE_TMPL = {
         'clientData': b'eyJ0eXBlIjogIndlYmF1dGhuLmNyZWF0ZSIsICJjbGllbnRFeHRlbnNpb25zIjoge30sICJjaGFsbGVuZ2UiOiAiYlB6cFgzaEhRdHNwOWV2eUtZa2FadFZjOVVOMDdQVWRKMjJ2WlVkRHA5NCIsICJvcmlnaW4iOiAiaHR0cHM6Ly93ZWJhdXRobi5pbyJ9',  # noqa
@@ -156,6 +155,27 @@ class WebAuthnRS256Test(WebAuthnES256Test):
     ICON_URL = "https://example.com/icon.png"
     USER_ID = b'\x80\xf1\xdc\xec\xb5\x18\xb1\xc8b\x05\x886\xbc\xdfJ\xdf'
 
+
+class WebAuthnEdDSATest(WebAuthnES256Test):
+    REGISTRATION_RESPONSE_TMPL = {
+        'clientData': b'eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiZ0I0bGJKMFNiY1VzSElBZ0NGUUNBRHNXZFdsbUlvNnZNdThDV0RZaFBCUSIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3Q6NTAwMCIsImNyb3NzT3JpZ2luIjpmYWxzZX0',  # noqa
+        'attObj': b'o2NmbXRmcGFja2VkZ2F0dFN0bXSjY2FsZyZjc2lnWEcwRQIhAJrjEo233rBVH4tL0V7v2lcjNBzYB_sZHB42fJysXo4OAiADsJdZmHyQIFgw1HNX2qm9eMVxckplr4oacD3EHNNIX2N4NWOBWQLBMIICvTCCAaWgAwIBAgIEK_F8eDANBgkqhkiG9w0BAQsFADAuMSwwKgYDVQQDEyNZdWJpY28gVTJGIFJvb3QgQ0EgU2VyaWFsIDQ1NzIwMDYzMTAgFw0xNDA4MDEwMDAwMDBaGA8yMDUwMDkwNDAwMDAwMFowbjELMAkGA1UEBhMCU0UxEjAQBgNVBAoMCVl1YmljbyBBQjEiMCAGA1UECwwZQXV0aGVudGljYXRvciBBdHRlc3RhdGlvbjEnMCUGA1UEAwweWXViaWNvIFUyRiBFRSBTZXJpYWwgNzM3MjQ2MzI4MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEdMLHhCPIcS6bSPJZWGb8cECuTN8H13fVha8Ek5nt-pI8vrSflxb59Vp4bDQlH8jzXj3oW1ZwUDjHC6EnGWB5i6NsMGowIgYJKwYBBAGCxAoCBBUxLjMuNi4xLjQuMS40MTQ4Mi4xLjcwEwYLKwYBBAGC5RwCAQEEBAMCAiQwIQYLKwYBBAGC5RwBAQQEEgQQxe9V_62aS5-1gK3rr-Am0DAMBgNVHRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQCLbpN2nXhNbunZANJxAn_Cd-S4JuZsObnUiLnLLS0FPWa01TY8F7oJ8bE-aFa4kTe6NQQfi8-yiZrQ8N-JL4f7gNdQPSrH-r3iFd4SvroDe1jaJO4J9LeiFjmRdcVa-5cqNF4G1fPCofvw9W4lKnObuPakr0x_icdVq1MXhYdUtQk6Zr5mBnc4FhN9qi7DXqLHD5G7ZFUmGwfIcD2-0m1f1mwQS8yRD5-_aDCf3vutwddoi3crtivzyromwbKklR4qHunJ75LGZLZA8pJ_mXnUQ6TTsgRqPvPXgQPbSyGMf2z_DIPbQqCD_Bmc4dj9o6LozheBdDtcZCAjSPTAd_uiaGF1dGhEYXRhWOFJlg3liA6MaHQ0Fw9kdmBbj-SuuaKGMseZXPO6gx2XY0EAAAACxe9V_62aS5-1gK3rr-Am0ACA66T2CBZBXT2qq3qQwO34IvlLsGV-YS4eS_AJnUodZSQ854CD3FEnhNVFg-cQR9XAFxZaaXTBOEMoKuDj0b9MltR4ITXMTbV2xRlg74QJKVj9dkX7YE5GQxSXcvIbfcn-iVpyKUfVicigDMAcDHxjmTweIQkLnpnCNujUP-GqXwSkAQEDJyAGIVggiB15haciBy1b5CW4osxvVaaEpPoZ3nZh3Ci1d-xspsc'  # noqa
+    }
+    ASSERTION_RESPONSE_TMPL = {
+        'authData': b'SZYN5YgOjGh0NBcPZHZgW4_krrmihjLHmVzzuoMdl2MBAAAAAw==',
+        'clientData': b'eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiQXp0aW1zaW83aTU5TENsVE9iZGlLbXlqdW42VDdWSF9ZRHJoRWZJR3ZXZyIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3Q6NTAwMCIsImNyb3NzT3JpZ2luIjpmYWxzZX0=',  # noqa
+        'signature': b'720b5e963760d2743f3a6f7d66e5b6d5be7b7abe328c3acfe6866f07c8ddd34244c0851fe3e021978f0d212e4203eadd8430fd7bec83a7c1bc929c22ed6eed0f',  # noqa
+    }
+    CRED_KEY = {'alg': -8, 'type': 'public-key'}
+    REGISTRATION_CHALLENGE = 'gB4lbJ0SbcUsHIAgCFQCADsWdWlmIo6vMu8CWDYhPBQ'
+    ASSERTION_CHALLENGE = 'Aztimsio7i59LClTObdiKmyjun6T7VH_YDrhEfIGvWg'
+    RP_ID = "localhost"
+    ORIGIN = "http://localhost:5000"
+    USER_NAME = 'testuser'
+    ICON_URL = "https://example.com/icon.png"
+    USER_DISPLAY_NAME = "A Test User"
+    USER_ID = b'!?~\xa5\xd9*\x95\xf5\x97\x8d;0\xcf\x8fkj\x13\xd2~\xb7'
+    RP_NAME = "Web Authentication"
 
 if __name__ == '__main__':
     unittest.main()

--- a/webauthn/webauthn.py
+++ b/webauthn/webauthn.py
@@ -32,6 +32,11 @@ from OpenSSL import crypto
 
 from . import const
 
+try:
+    from cryptography.hazmat.primitives.asymmetric import ed25519
+except Exception as e:
+    pass
+
 # Only supporting 'None', 'Basic', and 'Self Attestation' attestation types for now.
 AT_BASIC = 'Basic'
 AT_ECDAA = 'ECDAA'
@@ -51,6 +56,7 @@ SUPPORTED_ATTESTATION_FORMATS = (AT_FMT_FIDO_U2F, AT_FMT_PACKED, AT_FMT_NONE)
 COSE_ALG_ES256 = -7
 COSE_ALG_PS256 = -37
 COSE_ALG_RS256 = -257
+COSE_ALG_EdDSA = -8
 
 # Trust anchors (trusted attestation roots directory).
 DEFAULT_TRUST_ANCHOR_DIR = 'trusted_attestation_roots'
@@ -134,7 +140,10 @@ class WebAuthnMakeCredentialOptions(object):
             }, {
                 'alg': COSE_ALG_PS256,
                 'type': 'public-key',
-            }],
+            }, {
+                'alg': COSE_ALG_EdDSA,
+                'type': 'public-key',
+            },],
             'timeout': self.timeout,
             'excludeCredentials': [],
             # Relying Parties may use AttestationConveyancePreference to specify their
@@ -1119,7 +1128,6 @@ def _encode_public_key(public_key):
     return b'\x04' + binascii.unhexlify('{:064x}{:064x}'.format(
         numbers.x, numbers.y))
 
-
 def _load_cose_public_key(key_bytes):
     ALG_KEY = 3
 
@@ -1167,6 +1175,18 @@ def _load_cose_public_key(key_bytes):
 
         return alg, RSAPublicNumbers(e,
                                      n).public_key(backend=default_backend())
+    elif alg == COSE_ALG_EdDSA:
+        E_KEY = -2
+        N_KEY = -1
+
+        required_keys = {ALG_KEY, E_KEY, N_KEY}
+
+        if not set(cose_public_key.keys()).issuperset(required_keys):
+            raise COSEKeyException('Public key must match COSE_key spec.') 
+
+        if cose_public_key[N_KEY] != 6:
+            raise COSEKeyException("Unsupported elliptic curve, only Ed25519 supported")
+        return alg, ed25519.Ed25519PublicKey.from_public_bytes(cose_public_key[E_KEY])
     else:
         raise COSEKeyException('Unsupported algorithm.')
 
@@ -1369,5 +1389,7 @@ def _verify_signature(public_key, alg, data, signature):
     elif alg == COSE_ALG_PS256:
         padding = PSS(mgf=MGF1(SHA256()), salt_length=32)
         public_key.verify(signature, data, padding, SHA256())
+    elif alg == COSE_ALG_EdDSA:
+        public_key.verify(signature, data)
     else:
         raise NotImplementedError()

--- a/webauthn/webauthn.py
+++ b/webauthn/webauthn.py
@@ -34,8 +34,8 @@ from . import const
 
 try:
     from cryptography.hazmat.primitives.asymmetric import ed25519
-except Exception as e:
-    pass
+except ImportError as e:
+    ed25519 = None
 
 # Only supporting 'None', 'Basic', and 'Self Attestation' attestation types for now.
 AT_BASIC = 'Basic'
@@ -1128,6 +1128,7 @@ def _encode_public_key(public_key):
     return b'\x04' + binascii.unhexlify('{:064x}{:064x}'.format(
         numbers.x, numbers.y))
 
+
 def _load_cose_public_key(key_bytes):
     ALG_KEY = 3
 
@@ -1176,6 +1177,9 @@ def _load_cose_public_key(key_bytes):
         return alg, RSAPublicNumbers(e,
                                      n).public_key(backend=default_backend())
     elif alg == COSE_ALG_EdDSA:
+        if ed25519 is None:
+            raise COSEKeyException('Unsupported algorithm.')
+
         E_KEY = -2
         N_KEY = -1
 


### PR DESCRIPTION
This adds Ed25519 support to the webauthn library we are using. The tests use hardcoded data generated by a yubikey, just like the existing tests.